### PR TITLE
Add support for clients pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
 # vulcan-metrics-client
 Metrics client abstraction used in Vulcan components.
 
-Supports metrics types:
+### Configuration and behaviour
+
+Internally the client abstraction works as a pool of clients for the supported implementations. Each client is enabled/disabled and configured through environment variables, so for each input metric it will be pushed through every client in the pool.
+
+Current supported clients and its configurations are:
+DataDog
+- DOGSTATSD_ENABLED
+- DOGSTATSD_HOST
+- DOGSTATSD_PORT
+
+Metrics are divided in `Metric`, which defaults to a sample rate of 1.0, and `RatedMetric` which allows to specify its sample rate between 0 (everything is sampled) and 1 (no sample); see the [sample rates section](https://docs.datadoghq.com/developers/metrics/dogstatsd_metrics_submission/?tab=go#sample-rates) in DataDog.
+
+Current supported metric types are:
 - count
 - gauge
 - histogram
 - distribution
 
-Currently supports implementation for DataDog statsd service only.
-
-Metrics are divided in `Metric`, which defaults to a sample rate of 1.0, and `RatedMetric` which allows to specify its sample rate between 0 (everything is sampled) and 1 (no sample); see the [sample rates section](https://docs.datadoghq.com/developers/metrics/dogstatsd_metrics_submission/?tab=go#sample-rates) in DataDog.
-
 Example of pushing a metric:
 ```
-metricsClient, err := metrics.NewClient(metrics.DataDogClient, true, "localhost", 8125)
+metricsClient, err := metrics.NewClient()
 if err != nil {
     return err
 }
@@ -28,7 +36,7 @@ metricsClient.Push(metrics.Metric{
 
 Example of pushing a rated metric:
 ```
-metricsClient, err := metrics.NewClient(metrics.DataDogClient, true, "localhost", 8125)
+metricsClient, err := metrics.NewClient()
 if err != nil {
     return err
 }

--- a/client.go
+++ b/client.go
@@ -2,21 +2,9 @@ package metrics
 
 import (
 	"errors"
-	"os"
-	"strconv"
 )
 
 const (
-	// Config env variables.
-	envClientType = "METRICS_CLIENT_TYPE"
-	envEnabled    = "METRICS_ENABLED"
-	envHost       = "METRICS_HOST"
-	envPort       = "METRICS_PORT"
-
-	// DataDogClient represents the DataDog
-	// implementation for metrics client.
-	DataDogClient = "dd"
-
 	// Count represents a count metric type.
 	Count = iota
 	// Gauge represents a gauge metric type.
@@ -60,22 +48,7 @@ type Client interface {
 	PushWithRate(ratedMetric RatedMetric)
 }
 
-// NewClient creates a new metrics client based on given input.
-func NewClient(typ ClientType, enabled bool, host string, port int) (Client, error) {
-	switch typ {
-	case DataDogClient:
-		return newDDClient(enabled, host, port)
-	default:
-		return nil, ErrUnsupportedClientType
-	}
-}
-
-// NewClientFromEnv creates a new metrics client based on environment variables.
-func NewClientFromEnv() (Client, error) {
-	clientType := ClientType(os.Getenv(envClientType))
-	enabled, _ := strconv.ParseBool(os.Getenv(envEnabled))
-	host := os.Getenv(envHost)
-	port, _ := strconv.ParseInt(os.Getenv(envPort), 10, 0)
-
-	return NewClient(clientType, enabled, host, int(port))
+// NewClient creates a new metrics client based on environment variables.
+func NewClient() (Client, error) {
+	return newClientPool()
 }

--- a/client.go
+++ b/client.go
@@ -24,10 +24,6 @@ var (
 // Supports Count, Gauge, Histogram and Distribution types.
 type Type int
 
-// ClientType represents the requested metrics
-// client implementation.
-type ClientType string
-
 // Metric represents a metric.
 type Metric struct {
 	Name  string

--- a/client_pool.go
+++ b/client_pool.go
@@ -1,0 +1,55 @@
+package metrics
+
+// ClientPool represetns a metris client pool.
+type clientPool struct {
+	clients []Client
+}
+
+// clientConstructor represents a metrics client
+// constructor function.
+type clientConstructor func() (Client, error)
+
+var (
+	supportedClients = map[string]clientConstructor{
+		"DataDog": clientConstructor(newDDClientFromEnv),
+	}
+)
+
+// newClientPool creates a new ClientPool
+// parsing configuration from environment.
+//
+// Supported clients:
+//	- DataDog:
+//		DOGSTATSD_ENABLED
+//		DOGSTATSD_HOST
+//		DOGSTATSD_PORT
+func newClientPool() (Client, error) {
+	var clients []Client
+
+	for _, cconstructor := range supportedClients {
+		c, err := cconstructor()
+		if err != nil {
+			clients = append(clients, c)
+		}
+	}
+
+	return &clientPool{
+		clients: clients,
+	}, nil
+}
+
+// Push pushes the input metric for each
+// client in the pool.
+func (p *clientPool) Push(metric Metric) {
+	for _, c := range p.clients {
+		c.Push(metric)
+	}
+}
+
+// PushWithRate pushes the input rated metric
+// for each client in the pool.
+func (p *clientPool) PushWithRate(ratedMetric RatedMetric) {
+	for _, c := range p.clients {
+		c.PushWithRate(ratedMetric)
+	}
+}

--- a/client_pool.go
+++ b/client_pool.go
@@ -1,6 +1,6 @@
 package metrics
 
-// ClientPool represetns a metris client pool.
+// clientPool represents a metrics client pool.
 type clientPool struct {
 	clients []Client
 }
@@ -23,11 +23,11 @@ var (
 //		DOGSTATSD_ENABLED
 //		DOGSTATSD_HOST
 //		DOGSTATSD_PORT
-func newClientPool() (Client, error) {
+func newClientPool() (*clientPool, error) {
 	var clients []Client
 
-	for _, cconstructor := range supportedClients {
-		c, err := cconstructor()
+	for _, cConstructor := range supportedClients {
+		c, err := cConstructor()
 		if err != nil {
 			clients = append(clients, c)
 		}

--- a/client_pool_test.go
+++ b/client_pool_test.go
@@ -1,0 +1,167 @@
+package metrics
+
+import "testing"
+
+type mockClient struct {
+	pushCalls         int
+	pushWithRateCalls int
+}
+
+func (m *mockClient) Push(metric Metric) {
+	m.pushCalls++
+}
+
+func (m *mockClient) PushWithRate(ratedMetric RatedMetric) {
+	m.pushWithRateCalls++
+}
+
+func TestPoolPush(t *testing.T) {
+	testCases := []struct {
+		name                string
+		inputMetrics        []Metric
+		nClients            int
+		expectedClientCalls int
+	}{
+		{
+			name: "Happy path",
+			inputMetrics: []Metric{
+				{
+					Name:  "countMetricA",
+					Typ:   Count,
+					Value: 1,
+					Tags:  []string{"tag:mytag"},
+				},
+			},
+			nClients:            1,
+			expectedClientCalls: 1,
+		},
+		{
+			name: "Should push 3 metrics with 4 clients",
+			inputMetrics: []Metric{
+				{
+					Name:  "countMetricA",
+					Typ:   Count,
+					Value: 1,
+					Tags:  []string{"tag:mytag"},
+				},
+				{
+					Name:  "countMetricB",
+					Typ:   Count,
+					Value: 2,
+					Tags:  []string{"tag:mytagB"},
+				},
+				{
+					Name:  "histogramMetricA",
+					Typ:   Histogram,
+					Value: 4.2,
+					Tags:  []string{"tag:mytagC"},
+				},
+			},
+			nClients:            4,
+			expectedClientCalls: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		// given
+		var mockClients []*mockClient
+		for i := 0; i < tc.nClients; i++ {
+			mockClients = append(mockClients, &mockClient{})
+		}
+
+		clientPool := &clientPool{}
+		for i := 0; i < tc.nClients; i++ {
+			clientPool.clients = append(clientPool.clients, mockClients[i])
+		}
+
+		// when
+		for _, m := range tc.inputMetrics {
+			clientPool.Push(m)
+		}
+
+		// then
+		for _, mc := range mockClients {
+			if mc.pushCalls != tc.expectedClientCalls {
+				t.Fatalf("Error, expected push calls for each client to be: %d\nBut got: %d",
+					tc.expectedClientCalls, mc.pushCalls)
+			}
+		}
+	}
+}
+
+func TestPoolPushWithRate(t *testing.T) {
+	testCases := []struct {
+		name                string
+		inputMetrics        []RatedMetric
+		nClients            int
+		expectedClientCalls int
+	}{
+		{
+			name: "Happy path",
+			inputMetrics: []RatedMetric{
+				{
+					Metric: Metric{
+						Name:  "countMetricA",
+						Typ:   Count,
+						Value: 1,
+						Tags:  []string{"tag:mytag"},
+					},
+					Rate: 0.4,
+				},
+			},
+			nClients:            1,
+			expectedClientCalls: 1,
+		},
+		{
+			name: "Should push 2 metrics with 5 clients",
+			inputMetrics: []RatedMetric{
+				{
+					Metric: Metric{
+						Name:  "histogramMetricA",
+						Typ:   Histogram,
+						Value: 4.2,
+						Tags:  []string{"tag:mytagC"},
+					},
+					Rate: 1,
+				},
+				{
+					Metric: Metric{
+						Name:  "gaugeMetricA",
+						Typ:   Gauge,
+						Value: 7.1,
+						Tags:  []string{"tag:mytagD"},
+					},
+					Rate: 0.8,
+				},
+			},
+			nClients:            5,
+			expectedClientCalls: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		// given
+		var mockClients []*mockClient
+		for i := 0; i < tc.nClients; i++ {
+			mockClients = append(mockClients, &mockClient{})
+		}
+
+		clientPool := &clientPool{}
+		for i := 0; i < tc.nClients; i++ {
+			clientPool.clients = append(clientPool.clients, mockClients[i])
+		}
+
+		// when
+		for _, m := range tc.inputMetrics {
+			clientPool.PushWithRate(m)
+		}
+
+		// then
+		for _, mc := range mockClients {
+			if mc.pushWithRateCalls != tc.expectedClientCalls {
+				t.Fatalf("Error, expected push calls for each client to be: %d\nBut got: %d",
+					tc.expectedClientCalls, mc.pushWithRateCalls)
+			}
+		}
+	}
+}

--- a/dd.go
+++ b/dd.go
@@ -2,11 +2,20 @@ package metrics
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/DataDog/datadog-go/statsd"
 )
 
 const (
+	// DDEnabled represents the config env var to enabled DD client.
+	DDEnabled = "DOGSTATSD_ENABLED"
+	// DDHost represents the config env var to set DD client's statsd host.
+	DDHost = "DOGSTATSD_HOST"
+	// DDPort represents the config env var to set DD client's statsd port.
+	DDPort = "DOGSTATSD_PORT"
+
 	defaultHost = "localhost"
 	defaultPort = 8125
 )
@@ -20,7 +29,7 @@ type ddClient struct {
 type pushMetricsFunc func(name string, value, rate float64, tags []string)
 
 // newDDClient creates a new DataDog metrics client.
-func newDDClient(enabled bool, statsdHost string, statsdPort int) (*ddClient, error) {
+func newDDClient(enabled bool, statsdHost string, statsdPort int) (Client, error) {
 	if statsdHost == "" {
 		statsdHost = defaultHost
 	}
@@ -38,6 +47,16 @@ func newDDClient(enabled bool, statsdHost string, statsdPort int) (*ddClient, er
 		enabled:   enabled,
 		statsdCli: statsdCli,
 	}, nil
+}
+
+// newDDClientFromEnv creates a new DataDog metrics client
+// reading its configuration from environment.
+func newDDClientFromEnv() (Client, error) {
+	enabled, _ := strconv.ParseBool(os.Getenv(DDEnabled))
+	host := os.Getenv(DDHost)
+	port, _ := strconv.ParseInt(os.Getenv(DDPort), 10, 0)
+
+	return newDDClient(enabled, host, int(port))
 }
 
 // Push pushes the specified metric with rate 1.

--- a/dd_test.go
+++ b/dd_test.go
@@ -195,7 +195,7 @@ func verificationError(metric string, expected, actual interface{}) error {
 		metric, expected, actual)
 }
 
-func TestPush(t *testing.T) {
+func TestDDPush(t *testing.T) {
 	testCases := []struct {
 		metricsEnabled              bool
 		inputMetrics                []Metric
@@ -379,7 +379,7 @@ func TestPush(t *testing.T) {
 	}
 }
 
-func TestPushWithRate(t *testing.T) {
+func TestDDPushWithRate(t *testing.T) {
 	testCases := []struct {
 		metricsEnabled              bool
 		inputMetrics                []RatedMetric


### PR DESCRIPTION
This PR adds an intermediate abstraction layer for metrics client which acts as a pool of metrics clients itself, allowed to push metrics simultaneously to different services.